### PR TITLE
Remove show() to make package usable in terminal environments

### DIFF
--- a/antm/aligned_clustering_layer.py
+++ b/antm/aligned_clustering_layer.py
@@ -54,9 +54,7 @@ def draw_cluster(cluster_labels,umap,name,show_2d_plot,path):
     plt.scatter(data[0], data[1], c=data["C"])
     if not os.path.exists(path+"/results/partioned_clusters"): os.mkdir(path+"/results/partioned_clusters")
     plt.savefig(path+"/results/partioned_clusters/"+name+'.png')
-    if not show_2d_plot:
-        plt.close(fig)
-    plt.show()
+    plt.close(fig)
 
 def clustered_df(slices,clusters_labels):
     clustered_df=[]
@@ -142,7 +140,5 @@ def plot_alignment(df_tm,umap_embeddings_visualization,clusters_labels,path):
     fig = px.scatter_3d(x=ccs_df[0], y=ccs_df[1], z=ccs_df["win"],
                         color=ccs_df["evolving_topic"],color_continuous_scale=px.colors.sequential.Viridis)
     fig.update_layout(width=1000, height=1000)
-
-    fig.show()
     fig.write_image(path+"/results/fig_3D.png")
     return(list_tm)

--- a/antm/main.py
+++ b/antm/main.py
@@ -198,7 +198,6 @@ class ANTM:
             plt.legend()
 
         plt.savefig(self.path+'/results/random_topic_evolution.png')
-        plt.show()
 
     def save_evolution_topics_plots(self,display=False):
         for j in range(len(self.list_tm)):
@@ -225,7 +224,7 @@ class ANTM:
             if not os.path.exists(self.path+"/results/evolving_topics"): os.mkdir(self.path+"/results/evolving_topics")
             plt.savefig(self.path+'/results/evolving_topics/topic_evolution_' + str(j) + '.png')
             if display:
-                plt.show()
+                pass
             plt.close(fig)
 
     def plot_clusters_over_time(self):
@@ -252,7 +251,6 @@ class ANTM:
         plt.suptitle('Dynamic Document Embeddings and Clusters in each Time Frame')
         plt.savefig(self.path + "/results/partioned_topics.png")
         # Showing the figure
-        plt.show()
 
     def plot_evolving_topics(self):
 
@@ -278,7 +276,6 @@ class ANTM:
         plt.suptitle('Evolution of Evolving Topics')
         # Showing the figure
         plt.savefig(self.path+"/results/evolving_topics.png")
-        plt.show()
 
     def get_periodwise_puw_diversity(self):
         self.periodwise_puw_diversity=[proportion_unique_words(period, topk=self.num_words) for period in self.topics]


### PR DESCRIPTION
Hello, thanks for this awesome package! I've gone ahead and removed the calls to "show" for the figures that are being generated in the model.fit() method since the plots are saved anyway. The call to show would cause terminal sessions via ssh to get stuck in "HTTP request sent. Waiting for response." Because plotly renders pages in html which cannot be opened directly in a terminal. This is pure quality of life though, but I thought you may consider this pull request anyway. Thanks 